### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/jtolds/gls v0.0.0-20170503224851-77f18212c9c7 // indirect
 	github.com/lib/pq v0.0.0-20180523175426-90697d60dd84 // indirect
 	github.com/mattn/go-sqlite3 v1.9.0
-	github.com/miekg/dns v1.0.8
+	github.com/miekg/dns v1.1.25
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/smartystreets/assertions v0.0.0-20180607162144-eb5b59917fa2 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a // indirect


### PR DESCRIPTION
github.com/miekg/dns v1.0.8 is vulnerable so suggesting to upgrade the version to secured one. You can check vulnerability  of eh versions here : https://search.gocenter.io/github.com~2Fmiekg~2Fdns/info?version=v1.0.8

CVE-2019-19794 
  Medium
The miekg Go DNS package before 1.1.25, as used in CoreDNS before 1.6.6 and other products, improperly generates random numbers because math/rand is used. The TXID becomes predictable, leading to response forgeries. 
CVE-2018-17419 
  Medium
An issue was discovered in setTA in scan_rr.go in the Miek Gieben DNS library before 1.0.10 for Go. A dns.ParseZone() parsing error causes a segmentation violation, leading to denial of service.